### PR TITLE
new default kelp value and -v flag for cli

### DIFF
--- a/pyquarium/__init__.py
+++ b/pyquarium/__init__.py
@@ -17,7 +17,7 @@ import bext
 
 import pyquarium.aquarium as aq
 
-__version__ = 'v1.1.0'
+__version__ = 'v1.2.0'
 
 def render_aquarium(fish: int, bubblers: int, kelp: int, fps: int):
     """Print a moving aquarium to the terminal.

--- a/pyquarium/__main__.py
+++ b/pyquarium/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from pyquarium import render_aquarium
+from pyquarium import render_aquarium, __version__
 
 
 def _get_args() -> argparse.Namespace:
@@ -14,10 +14,12 @@ def _get_args() -> argparse.Namespace:
                         help='default=8, max=30, min=0')
     parser.add_argument('-b', '--bubblers', nargs='?', default=3, type=int,
                         help='default=3, max=15, min=0')
-    parser.add_argument('-k', '--kelp', nargs='?', default=4, type=int,
-                        help='default=4, max=15, min=0')
+    parser.add_argument('-k', '--kelp', nargs='?', default=5, type=int,
+                        help='default=5, max=15, min=0')
     parser.add_argument('fps', nargs='?', default=6, type=int,
                         help='default=6, max=45, min=1')
+    parser.add_argument('-v', '--version', action='version',
+                        version=f'%(prog)s version {__version__}')
     return parser.parse_args()
 
 


### PR DESCRIPTION
Changed the default kelp value from 4 to 5 as I prefer it. I also added a -v/--version argument to the cli for printing the version number.