### PR TITLE
moved try-catch for a cleaner exit on keyboard interrupt

### DIFF
--- a/pyquarium/__init__.py
+++ b/pyquarium/__init__.py
@@ -16,7 +16,7 @@ import time
 
 import pyquarium.aquarium as aq
 
-__version__ = 'v1.4.2'
+__version__ = 'v1.4.3'
 
 def render_aquarium(fish_count: int, bubbler_count: int, kelp_count: int,
                     fps: int):
@@ -117,4 +117,7 @@ def render_aquarium(fish_count: int, bubbler_count: int, kelp_count: int,
             stdscr.refresh()
             time.sleep(1 / denominator)
 
-    curses.wrapper(main)
+    try:
+        curses.wrapper(main)
+    except KeyboardInterrupt:
+        curses.endwin()

--- a/pyquarium/__main__.py
+++ b/pyquarium/__main__.py
@@ -23,8 +23,5 @@ def _get_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-args= _get_args()
-try:
-    render_aquarium(args.fish, args.bubblers, args.kelp, args.fps)
-except KeyboardInterrupt:
-    sys.exit()
+args = _get_args()
+render_aquarium(args.fish, args.bubblers, args.kelp, args.fps)

--- a/pyquarium/aquarium.py
+++ b/pyquarium/aquarium.py
@@ -118,7 +118,8 @@ class Fish:
             fish_text = self.left[self.counter % len(self.left)]
         x_position = self.x
         for i, fish_part in enumerate(fish_text):
-            stdscr.addstr(self.y, self.x, fish_part, curses.color_pair(self.color[i]))
+            stdscr.addstr(self.y, self.x, fish_part,
+                          curses.color_pair(self.color[i]))
             self.x += 1
         self.x = x_position
 


### PR DESCRIPTION
Fix and issue that when built and run as a binary using pysinstaller, the existing try-catch block wouldn't properly catch a keyboard interrupt and exit cleanly.